### PR TITLE
No longer dumping core when invalid filenames given to tests.

### DIFF
--- a/tests/churn/churn.cpp
+++ b/tests/churn/churn.cpp
@@ -69,6 +69,10 @@ public:
         num_churn_pages = options.num_churn_pages;
 
         base_addr = PerFile_openandmap(&umt_options, (num_churn_pages + num_rw_load_pages + num_read_load_pages) * pagesize);
+        if ( base_addr == nullptr ) {
+          exit(1);
+        }
+
         assert(base_addr != NULL);
 
         read_load_pages = base_addr;
@@ -90,7 +94,7 @@ public:
             << options.fn << " Backing file\n\t"
             << options.testduration << " seconds for test duration.\n\n";
 
-        //check();
+        check();
     }
 
     ~pageiotest( void ) {
@@ -161,7 +165,7 @@ private:
           for (uint64_t i = 0; i < num_churn_pages * (pagesize/sizeof(*p)); i += (pagesize/sizeof(*p)))
               if (p[i] != i) {
                 cerr << "check(CHURN): *(uint64_t*)" << &p[i] << "=" << p[i] << " != " << (unsigned long long)i << endl;
-                return;
+                exit(1);
               }
         }
         cout << "Checking read load pages\n";
@@ -170,7 +174,7 @@ private:
           for (uint64_t i = 0; i < num_read_load_pages * (pagesize/sizeof(*p)); ++i)
               if (p[i] != i) {
                 cerr << "check(READER): *(uint64_t*)" << &p[i] << "=" << p[i] << " != " << (unsigned long long)i << endl;
-                break;
+                exit(1);
               }
         }
         cerr << "Check Complete\n";

--- a/tests/lib/PerFits/PerFits.cpp
+++ b/tests/lib/PerFits/PerFits.cpp
@@ -104,8 +104,13 @@ void* PerFits_alloc_cube(
     ss << basename << std::setfill('0') << std::setw(3) << i << ".fits";
     struct stat sbuf;
 
-    if ( stat(ss.str().c_str(), &sbuf) == -1 )
+    if ( stat(ss.str().c_str(), &sbuf) == -1 ) {
+      if ( i == 1 ) {
+        cerr << "File: " << ss.str() << " does not exist\n";
+        return region;
+      }
       break;
+    }
 
     Fits::Tile T(ss.str());
 
@@ -127,6 +132,7 @@ void* PerFits_alloc_cube(
 
     cube->tiles.push_back(T);
   }
+
 
   const int prot = PROT_READ|PROT_WRITE;
   int flags = UMAP_PRIVATE;

--- a/tests/lib/PerFits/Tile.cpp
+++ b/tests/lib/PerFits/Tile.cpp
@@ -52,32 +52,32 @@ Tile::Tile(const std::string& _fn)
 
   if ( fits_open_data(&fptr, file.fname.c_str(), READONLY, &status) ) {
     fits_report_error(stderr, status);
-    assert("NOT a FITS file" && 0);
+    exit(-1);
   }
 
   if ( fits_get_hduaddrll(fptr, &headstart, &datastart, &dataend, &status) ) {
     fits_report_error(stderr, status);
-    assert("FITs failed to read hduaddrll" && 0);
+    exit(-1);
   }
 
   if ( fits_get_img_type(fptr, &bitpix, &status) ) {
     fits_report_error(stderr, status);
-    assert("FITs failed to get image type" && 0);
+    exit(-1);
   }
 
   if ( fits_get_img_param(fptr, 2, &bitpix, &naxes, &naxis[0], &status) ) {
     fits_report_error(stderr, status);
-    assert("FITs failed to get image param" && 0);
+    exit(-1);
   }
 
   if ( fits_close_file(fptr, &status) ) {
     fits_report_error(stderr, status);
-    assert("FITs failed to close file" && 0);
+    exit(-1);
   }
 
   if ( ( file.fd = open(file.fname.c_str(), (O_RDONLY | O_LARGEFILE)) ) == -1 ) {
     perror(file.fname.c_str());
-    assert("Open failure" && 0);
+    exit(-1);
   }
 
   dim.xDim = (size_t)naxis[0];

--- a/tests/median_calculation/random_vector_median_calculation.cpp
+++ b/tests/median_calculation/random_vector_median_calculation.cpp
@@ -59,6 +59,9 @@ int main(int argc, char** argv)
   median::cube_t<pixel_type> cube;
 
   cube.data = (pixel_type*)PerFits::PerFits_alloc_cube(&options, &BytesPerElement, &xDim, &yDim, &zDim);
+  if (cube.data == nullptr) {
+    return -1;
+  }
 
   cube.size_x = xDim;
   cube.size_y = yDim;
@@ -103,4 +106,6 @@ int main(int argc, char** argv)
   }
 
   PerFits::PerFits_free_cube(cube.data);
+
+  return 0;
 }

--- a/tests/median_calculation/simple_median_calculation_example.cpp
+++ b/tests/median_calculation/simple_median_calculation_example.cpp
@@ -36,6 +36,10 @@ int main(int argc, char** argv)
 
   cube.data = (float*)PerFits::PerFits_alloc_cube(&options, &BytesPerElement, &xDim, &yDim, &zDim);
 
+  if (cube.data == nullptr) {
+    return -1;
+  }
+
   cube.size_x = xDim;
   cube.size_y = yDim;
   cube.size_k = zDim; // tne number of frames
@@ -47,4 +51,6 @@ int main(int argc, char** argv)
   }
 
   PerFits::PerFits_free_cube(cube.data);
+
+  return 0;
 }

--- a/tests/umapsort/umapsort.cpp
+++ b/tests/umapsort/umapsort.cpp
@@ -144,7 +144,8 @@ int main(int argc, char **argv)
 
   totalbytes = options.numpages*pagesize;
   base_addr = PerFile_openandmap(&options, totalbytes);
-  assert(base_addr != NULL);
+  if (base_addr == nullptr)
+    return -1;
  
   fprintf(stdout, "%lu pages, %llu bytes, %lu threads\n", options.numpages, totalbytes, options.numthreads);
 


### PR DESCRIPTION
Minor cleanup - (regression tests pass)