### PR TITLE
Add median calculation (and cfitsio) to automated regression tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,13 +10,13 @@ OPTION (ENABLE_TESTS "Selects whether tests are built." On)
 OPTION (ENABLE_LOGGING "Build umap with Logging enabled" On)
 OPTION (ENABLE_STATS "Enable display statistics on exit" Off)
 
-include(cmake/BuildEnv.cmake)
-include(cmake/BuildType.cmake)
-include(cmake/SetupUmapThirdParty.cmake)
-
 set(UMAP_ENABLE_LOGGING ${ENABLE_LOGGING})
 set(UMAP_ENABLE_CFITS ${ENABLE_CFITS})
 set(UMAP_DISPLAY_STATS ${ENABLE_STATS})
+
+include(cmake/BuildEnv.cmake)
+include(cmake/BuildType.cmake)
+include(cmake/SetupUmapThirdParty.cmake)
 
 configure_file(
   ${PROJECT_SOURCE_DIR}/config/config.h.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ OPTION (ENABLE_STATS "Enable display statistics on exit" Off)
 set(UMAP_ENABLE_LOGGING ${ENABLE_LOGGING})
 set(UMAP_ENABLE_CFITS ${ENABLE_CFITS})
 set(UMAP_DISPLAY_STATS ${ENABLE_STATS})
+set(UMAP_DEBUG_LOGGING ${ENABLE_LOGGING})
 
 include(cmake/BuildEnv.cmake)
 include(cmake/BuildType.cmake)

--- a/cmake/SetupUmapThirdParty.cmake
+++ b/cmake/SetupUmapThirdParty.cmake
@@ -1,14 +1,15 @@
 if ( ENABLE_CFITS )
   FIND_PACKAGE(CURL)
+  if ( NOT CURL_FOUND )
+    message (FATAL_ERROR "Could not find CURL libraries which are needed by cfitsio")
+  endif()
 
   find_library( CFITS_LIBRARY libcfitsio.a PATHS ${CFITS_LIBRARY_PATH} )
   if ( NOT CFITS_LIBRARY )
     message( FATAL_ERROR "Could not find CFITS library, make sure CFITS_LIBRARY_PATH is set properly")
   endif()
 
-  find_library( BZ2_LIBRARY libbz2.so PATHS ${CFITS_LIBRARY_PATH} )
-  find_library( ZLIB_LIBRARY libz.so PATHS ${CFITS_LIBRARY_PATH} )
-  set(CFITS_LIBRARIES ${CFITS_LIBRARY} ${BZ2_LIBRARY} ${ZLIB_LIBRARY})
+  set(CFITS_LIBRARIES ${CFITS_LIBRARY} ${CURL_LIBRARIES} )
 
   find_path( CFITS_INCLUDE_DIR fitsio.h PATHS ${CFITS_INCLUDE_PATH} )
   if ( NOT CFITS_INCLUDE_DIR )

--- a/cmake/SetupUmapThirdParty.cmake
+++ b/cmake/SetupUmapThirdParty.cmake
@@ -1,7 +1,7 @@
 if ( ENABLE_CFITS )
   FIND_PACKAGE(CURL)
   if ( NOT CURL_FOUND )
-    message (FATAL_ERROR "Could not find CURL libraries which are needed by cfitsio")
+    message ( STATUS "CURL library not found, will attempt to use cfitsio without CURL support")
   endif()
 
   find_library( CFITS_LIBRARY libcfitsio.a PATHS ${CFITS_LIBRARY_PATH} )

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -5,4 +5,5 @@
 #define UMAP_VERSION_MINOR @umap_VERSION_MINOR@
 #define UMAP_VERSION_PATCH @umap_VERSION_PATCH@
 #cmakedefine UMAP_DISPLAY_STATS
+#cmakedefine UMAP_DEBUG_LOGGING
 #endif

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -39,5 +39,8 @@ trycmd "make -j"
 
 trycmd "./tests/churn/churn --directio -f /tmp/regression_test_churn.dat -b 10000 -c 20000 -l 1000 -d 10"
 trycmd "./tests/umapsort/umapsort -p 100000 -b 95000 -f /tmp/regression_test_sort.dat --directio -t 16"
-/bin/rm -f /tmp/regression_test_churn.dat /tmp/regression_test_sort.dat
+trycmd "tar xvf ${UMAP_DIR}/tests/median_calculation/data/test_fits_files.tar.gz -C /tmp/"
+trycmd "./tests/median_calculation/test_median_calculation -f /tmp/test_fits_files/asteroid_sim_epoch00"
+trycmd "./tests/median_calculation/umapsort -p 100000 -b 95000 -f /tmp/regression_test_sort.dat --directio -t 16"
+/bin/rm -f /tmp/regression_test_churn.dat /tmp/regression_test_sort.dat /tmp/test_fits_files
 

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -37,10 +37,10 @@ trycmd "cmake -C ${UMAP_DIR}/host-configs/${SYS_TYPE}/${COMPILER}.cmake -DCMAKE_
 
 trycmd "make -j"
 
+/bin/rm -rf /tmp/regression_test_churn.dat /tmp/regression_test_sort.dat /tmp/test_fits_files
 trycmd "./tests/churn/churn --directio -f /tmp/regression_test_churn.dat -b 10000 -c 20000 -l 1000 -d 10"
 trycmd "./tests/umapsort/umapsort -p 100000 -b 95000 -f /tmp/regression_test_sort.dat --directio -t 16"
 trycmd "tar xvf ${UMAP_DIR}/tests/median_calculation/data/test_fits_files.tar.gz -C /tmp/"
 trycmd "./tests/median_calculation/test_median_calculation -f /tmp/test_fits_files/asteroid_sim_epoch00"
-trycmd "./tests/median_calculation/umapsort -p 100000 -b 95000 -f /tmp/regression_test_sort.dat --directio -t 16"
-/bin/rm -f /tmp/regression_test_churn.dat /tmp/regression_test_sort.dat /tmp/test_fits_files
+/bin/rm -rf /tmp/regression_test_churn.dat /tmp/regression_test_sort.dat /tmp/test_fits_files
 

--- a/scripts/bamboo/build_and_test.sh
+++ b/scripts/bamboo/build_and_test.sh
@@ -28,7 +28,7 @@ export BUILD_DIR=build-${SYS_TYPE}
 
 export COMPILER=${1:-gcc_4_8_5}
 export BUILD_TYPE=${2:-Release}
-export BUILD_OPTIONS="-DENABLE_STATS=On -DENABLE_CFITS=Off -DENABLE_FITS_TESTS=Off ${BUILD_OPTIONS}"
+export BUILD_OPTIONS="-DENABLE_STATS=On -DENABLE_CFITS=On -DENABLE_FITS_TESTS=On -DCFITS_LIBRARY_PATH=/g/g0/martymcf/.bin/toss_3_x86_64/lib -DCFITS_INCLUDE_PATH=/g/g0/martymcf/.bin/toss_3_x86_64/include ${BUILD_OPTIONS}"
 
 mkdir ${BUILD_DIR} 2> /dev/null
 cd ${BUILD_DIR}

--- a/src/logging/spindle_debug.h
+++ b/src/logging/spindle_debug.h
@@ -31,11 +31,10 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <stdio.h>
 #include <unistd.h>
+#include "config.h"
 
-#define LOGD_DEBUG
+#if defined(UMAP_DEBUG_LOGGING)
 
-#if defined(LOGD_DEBUG)
-#define LDCSDEBUG 1
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -43,31 +42,16 @@ extern "C" {
 #if defined(__cplusplus)
 }
 #endif
-#elif defined(DEBUG)
-#define LDCSDEBUG 1
-#define debug_printf(format, ...) \
-  do { \
-     fprintf(stderr, "[%s:%u@%d] - " format, __FILE__, __LINE__, getpid(), ## __VA_ARGS__); \
-  } while (0)
-#elif defined(SIONDEBUG)
-#define LDCSDEBUG 1
-#include "sion_debug.h"
-#define debug_printf(format, ...) \
-  do { \
-    sion_dprintfp(32, __FILE__, getpid(), "[L%04u, %12.2f] - " format, __LINE__,_sion_get_time(), ## __VA_ARGS__); \
-  } while (0)
-#else
-#define debug_printf(format, ...)
-#endif
 
-#if defined(LOGD_DEBUG)
 #define LOGGING_INIT init_spindle_debugging(0)
 #define LOGGING_INIT_PREEXEC init_spindle_debugging(1)
 #define LOGGING_FINI fini_spindle_debugging()
+
 #else
 #define LOGGING_INIT
 #define LOGGING_INIT_PREEXEC
 #define LOGGING_FINI
+#define debug_printf(format, ...)
 #define debug_printf2(S, ...) debug_printf(S, ## __VA_ARGS__)
 #define debug_printf3(S, ...) debug_printf(S, ## __VA_ARGS__)
 

--- a/src/logging/spindle_logc.c
+++ b/src/logging/spindle_logc.c
@@ -27,10 +27,10 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 */
 #define _GNU_SOURCE
 
-#include "spindle_debug.h"
-#include "spindle_logc.h"
 #include "config.h"
 
+#if defined(UMAP_DEBUG_LOGGING)
+#include "spindle_debug.h"
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/types.h>
@@ -370,12 +370,6 @@ void spindle_dump_on_error()
    char **syms;
    int size, i;
 
-#if 0
-   if (strstr(spindle_debug_name, "Client")) {
-      return;
-   }
-#endif
-
    size = backtrace(stacktrace, 256);
    if (size <= 0)
       return;
@@ -400,3 +394,4 @@ int is_debug_fd(int fd)
 {
    return (fd == debug_fd);
 }
+#endif

--- a/src/umap/umap.cpp
+++ b/src/umap/umap.cpp
@@ -263,7 +263,7 @@ void* umap(void* base_addr, uint64_t region_size, int prot, int flags, umap_psto
     return NULL;
   }
 
-  if (!(flags & UM AP_PRIVATE) || flags & ~(UMAP_PRIVATE|UMAP_FIXED)) {
+  if (!(flags & UMAP_PRIVATE) || flags & ~(UMAP_PRIVATE|UMAP_FIXED)) {
     cerr << "umap: Invalid flags: " << hex << flags << endl;
     return UMAP_FAILED;
   }

--- a/src/umap/umap.cpp
+++ b/src/umap/umap.cpp
@@ -263,7 +263,7 @@ void* umap(void* base_addr, uint64_t region_size, int prot, int flags, umap_psto
     return NULL;
   }
 
-  if (!(flags & UMAP_PRIVATE) || flags & ~(UMAP_PRIVATE|UMAP_FIXED)) {
+  if (!(flags & UM AP_PRIVATE) || flags & ~(UMAP_PRIVATE|UMAP_FIXED)) {
     cerr << "umap: Invalid flags: " << hex << flags << endl;
     return UMAP_FAILED;
   }
@@ -303,7 +303,7 @@ uint64_t* umap_cfg_readenv(const char* env, uint64_t* val) {
   char* val_ptr = 0;
   if ( (val_ptr = getenv(env)) ) {
     uint64_t env_val = 0;
-    if (sscanf(val_ptr, "%"PRIu64, &env_val)) {
+    if (sscanf(val_ptr, "%" PRIu64, &env_val)) {
       *val = env_val;
       return val;
     }

--- a/tests/median_calculation/CMakeLists.txt
+++ b/tests/median_calculation/CMakeLists.txt
@@ -10,7 +10,7 @@ if(OPENMP_FOUND)
 
     add_executable(test_median_calculation test_median_calculation.cpp)
     add_dependencies(test_median_calculation libtestoptions libumap libPerFile libPerFits )
-    target_link_libraries(test_median_calculation libumap libtestoptions libPerFits ${CFITS_LIBRARY} )
+    target_link_libraries(test_median_calculation libumap libtestoptions libPerFits ${CFITS_LIBRARIES} )
     install(TARGETS test_median_calculation
             LIBRARY DESTINATION lib
             ARCHIVE DESTINATION lib/static
@@ -18,7 +18,7 @@ if(OPENMP_FOUND)
 
     add_executable(run_random_vector run_random_vector.cpp)
     add_dependencies(run_random_vector libumap libtestoptions libPerFits )
-    target_link_libraries(run_random_vector libumap libtestoptions libPerFits ${CFITS_LIBRARY} )
+    target_link_libraries(run_random_vector libumap libtestoptions libPerFits ${CFITS_LIBRARIES} )
     install(TARGETS run_random_vector
             LIBRARY DESTINATION lib
             ARCHIVE DESTINATION lib/static


### PR DESCRIPTION
This small set of changes will allow us to build with the cfitsio library on multiple systems including our TOSS3 CI system.  This automated CI scripts will now also run our median calculation test as part of our standard regression tests.

I also fixed a bug with the logging demon not being launched when a user tries to run umap programs from the build directory instead of the install directory.