### PR TITLE
Bugfix/umapsort fix

### DIFF
--- a/tests/lib/options/testoptions.cpp
+++ b/tests/lib/options/testoptions.cpp
@@ -153,6 +153,13 @@ void umt_getoptions(umt_optstruct_t* testops, int argc, char *argv[])
     usage(pname);
   }
 
+  /*
+   * Note: Care must be taken when configuring the number of threads
+   * and the buffer size of umap.  When the buffer size is set, it
+   * apportions the buffer evenly to the umap threads.  So setting the
+   * buffer size requires that the number of threads be set properly
+   * first.
+   */
   if (testops->uffdthreads != umap_cfg_get_uffdthreads())
     umap_cfg_set_uffdthreads(testops->uffdthreads);
 

--- a/tests/lib/options/testoptions.cpp
+++ b/tests/lib/options/testoptions.cpp
@@ -153,10 +153,10 @@ void umt_getoptions(umt_optstruct_t* testops, int argc, char *argv[])
     usage(pname);
   }
 
-  umap_cfg_set_bufsize(testops->bufsize);
-
   if (testops->uffdthreads != umap_cfg_get_uffdthreads())
     umap_cfg_set_uffdthreads(testops->uffdthreads);
+
+  umap_cfg_set_bufsize(testops->bufsize);
 }
 
 long umt_getpagesize(void)

--- a/tests/umapsort/umapsort.cpp
+++ b/tests/umapsort/umapsort.cpp
@@ -149,7 +149,6 @@ int main(int argc, char **argv)
     return -1;
  
   fprintf(stdout, "umap INIT took %f seconds\n", (double)(getns() - start)/1000000000.0);
-#ifdef taken_out
   fprintf(stdout, "%lu pages, %llu bytes, %lu threads\n", options.numpages, totalbytes, options.numthreads);
 
   uint64_t *arr = (uint64_t *) base_addr; 
@@ -182,7 +181,6 @@ int main(int argc, char **argv)
     validatedata(arr, arraysize);
     fprintf(stdout, "Validate took %f seconds\n", (double)(getns() - start)/1000000000.0);
   }
-#endif
   
   start = getns();
   PerFile_closeandunmap(&options, totalbytes, base_addr);


### PR DESCRIPTION
The previously committed version of umapsort had the actual sorting implementation commented out for testing INIT/TERM times.  This commit uncomments the code so that the sort will again run.

Also, it was found that the options library was setting the number of UMAP threads and the UMAP buffer size in the incorrect order which would produce some unexpected results.