### PR TITLE
Added -DENABLE_DISPLAY_STATS option to display statistics before uunmap returns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,14 @@ project(umap
 
 OPTION (ENABLE_TESTS "Selects whether tests are built." On)
 OPTION (ENABLE_LOGGING "Build umap with Logging enabled" On)
+OPTION (ENABLE_DISPLAY_STATS "Display umap statistics when closing" Off)
 
 include(cmake/BuildEnv.cmake)
 include(cmake/BuildType.cmake)
 include(cmake/SetupUmapThirdParty.cmake)
 
 set(UMAP_DEBUG_LOGGING ${ENABLE_LOGGING})
+set(UMAP_DISPLAY_STATS ${ENABLE_DISPLAY_STATS})
 configure_file(
   ${PROJECT_SOURCE_DIR}/config/config.h.in
   ${PROJECT_BINARY_DIR}/src/umap/config.h)

--- a/config/config.h.in
+++ b/config/config.h.in
@@ -11,4 +11,5 @@
 #define UMAP_VERSION_MINOR @umap_VERSION_MINOR@
 #define UMAP_VERSION_PATCH @umap_VERSION_PATCH@
 #cmakedefine UMAP_DEBUG_LOGGING
+#cmakedefine UMAP_DISPLAY_STATS
 #endif

--- a/docs/sphinx/advanced_configuration.rst
+++ b/docs/sphinx/advanced_configuration.rst
@@ -18,6 +18,7 @@ Here is a summary of the configuration options, their default value, and meaning
       Variable                     Default  Meaning
       ===========================  ======== ==========================================
       ``ENABLE_LOGGING``           On       Enable Logging within umap
+      ``ENABLE_DISPLAY_STATS``     Off      Enable Displaying umap stats at close
       ``ENABLE_TESTS``             On       Enable building and installation of tests
       ``CMAKE_CXX_COMPILER``       not set  Specify C++ compiler to use
       ``DCMAKE_CC_COMPILER``       not set  Specify C compiler to use
@@ -30,6 +31,10 @@ These arguments are explained in more detail below:
   enabled, you may cause umap library to emit log files by setting the ``UMAP_LOGGING``
   environment variable to "1" (for information-only logs), "2" (for more verbose
   logs), and "3" for all debug messages to be emitted to a log file.
+
+* ``ENABLE_DISPLAY_STATS``
+  When this option is turned on, the umap library will display its runtime
+  statistics before unmap() completes.
 
 * ``ENABLE_TESTS``
   This option enables the compilation of the programs under the tests directory

--- a/src/umap/Buffer.cpp
+++ b/src/umap/Buffer.cpp
@@ -8,6 +8,7 @@
 #include <pthread.h>
 
 #include "umap/Buffer.hpp"
+#include "umap/config.h"
 #include "umap/FillWorkers.hpp"
 #include "umap/PageDescriptor.hpp"
 #include "umap/RegionManager.hpp"
@@ -345,7 +346,9 @@ Buffer::Buffer( void )
 }
 
 Buffer::~Buffer( void ) {
-  UMAP_LOG(Debug, m_stats);
+#ifdef UMAP_DISPLAY_STATS
+  std::cout << m_stats << std::endl;
+#endif
 
   assert("Pages are still present" && m_present_pages.size() == 0);
   pthread_cond_destroy(&m_avail_pd_cond);


### PR DESCRIPTION
Building with this option will cause the umap library to print out its statistics counters before uunmap() returns at the end of a run.