### PR TITLE
Make umap() and uunmap() API calls thread-safe

### DIFF
--- a/src/umap/Buffer.hpp
+++ b/src/umap/Buffer.hpp
@@ -48,7 +48,7 @@ namespace Umap {
       ~Buffer( void );
 
     private:
-      RegionManager* m_rm;
+      RegionManager& m_rm;
       uint64_t m_size;          // Maximum pages this buffer may have
       PageDescriptor* m_array;
 

--- a/src/umap/EvictManager.cpp
+++ b/src/umap/EvictManager.cpp
@@ -67,10 +67,10 @@ void EvictManager::schedule_eviction(PageDescriptor* pd)
 
 EvictManager::EvictManager( void ) :
         WorkerPool("Evict Manager", 1)
-      , m_buffer(RegionManager::getInstance()->get_buffer_h())
+      , m_buffer(RegionManager::getInstance().get_buffer_h())
 {
-  m_evict_workers = new EvictWorkers(  RegionManager::getInstance()->get_num_evictors()
-                                     , m_buffer, RegionManager::getInstance()->get_uffd_h());
+  m_evict_workers = new EvictWorkers(  RegionManager::getInstance().get_num_evictors()
+                                     , m_buffer, RegionManager::getInstance().get_uffd_h());
   start_thread_pool();
 }
 

--- a/src/umap/EvictWorkers.cpp
+++ b/src/umap/EvictWorkers.cpp
@@ -18,7 +18,7 @@
 namespace Umap {
 void EvictWorkers::EvictWorker( void )
 {
-  uint64_t page_size = RegionManager::getInstance()->get_umap_page_size();
+  uint64_t page_size = RegionManager::getInstance().get_umap_page_size();
 
   while ( 1 ) {
     auto w = get_work();

--- a/src/umap/FillWorkers.cpp
+++ b/src/umap/FillWorkers.cpp
@@ -22,8 +22,8 @@
 namespace Umap {
   void FillWorkers::FillWorker( void ) {
     char* copyin_buf;
-    uint64_t page_size = RegionManager::getInstance()->get_umap_page_size();
-    uint64_t read_ahead = RegionManager::getInstance()->get_read_ahead();
+    uint64_t page_size = RegionManager::getInstance().get_umap_page_size();
+    uint64_t read_ahead = RegionManager::getInstance().get_read_ahead();
     std::size_t sz = 2 * page_size;
 
     if (posix_memalign((void**)&copyin_buf, page_size, sz)) {
@@ -73,10 +73,10 @@ namespace Umap {
   }
 
   FillWorkers::FillWorkers( void )
-    :   WorkerPool("Fill Workers", RegionManager::getInstance()->get_num_fillers())
-      , m_uffd(RegionManager::getInstance()->get_uffd_h())
-      , m_buffer(RegionManager::getInstance()->get_buffer_h())
-      , m_read_ahead(RegionManager::getInstance()->get_read_ahead())
+    :   WorkerPool("Fill Workers", RegionManager::getInstance().get_num_fillers())
+      , m_uffd(RegionManager::getInstance().get_uffd_h())
+      , m_buffer(RegionManager::getInstance().get_buffer_h())
+      , m_read_ahead(RegionManager::getInstance().get_read_ahead())
   {
     start_thread_pool();
   }

--- a/src/umap/RegionManager.hpp
+++ b/src/umap/RegionManager.hpp
@@ -8,6 +8,7 @@
 #define _UMAP_RegionManager_HPP
 
 #include <cstdint>
+#include <mutex>
 #include <unordered_map>
 
 #include "umap/Buffer.hpp"
@@ -36,7 +37,13 @@ struct Version {
 //
 class RegionManager {
   public:
-    static RegionManager* getInstance( void );
+    static RegionManager& getInstance( void );
+
+    // delete copy, move, and assign operators
+    RegionManager(RegionManager const&) = delete;             // Copy construct
+    RegionManager(RegionManager&&) = delete;                  // Move construct
+    RegionManager& operator=(RegionManager const&) = delete;  // Copy assign
+    RegionManager& operator=(RegionManager &&) = delete;      // Move assign
 
     void addRegion(
           Store*   store
@@ -80,10 +87,9 @@ class RegionManager {
     Uffd* m_uffd;
     FillWorkers* m_fill_workers;
     EvictManager* m_evict_manager;
+    std::mutex m_mutex;
 
     std::unordered_map<void*, RegionDescriptor*> m_active_regions;
-
-    static RegionManager* s_fault_monitor_manager_instance;
 
     RegionManager( void );
 

--- a/src/umap/Uffd.cpp
+++ b/src/umap/Uffd.cpp
@@ -125,7 +125,7 @@ Uffd::uffd_handler( void )
 void
 Uffd::process_page( bool iswrite, char* addr )
 {
-  auto rd = m_rm->containing_region(addr);
+  auto rd = m_rm.containing_region(addr);
   if ( rd == nullptr )
     UMAP_ERROR("Invalid page: " << addr);
 
@@ -141,9 +141,9 @@ Uffd::ThreadEntry()
 Uffd::Uffd( void )
   :   WorkerPool("Uffd Manager", 1)
     , m_rm(RegionManager::getInstance())
-    , m_max_fault_events(m_rm->get_max_fault_events())
-    , m_page_size(m_rm->get_umap_page_size())
-    , m_buffer(m_rm->get_buffer_h())
+    , m_max_fault_events(m_rm.get_max_fault_events())
+    , m_page_size(m_rm.get_umap_page_size())
+    , m_buffer(m_rm.get_buffer_h())
 {
   UMAP_LOG(Debug, "\n maximum fault events: " << m_max_fault_events
                   << "\n            page size: " << m_page_size);

--- a/src/umap/Uffd.hpp
+++ b/src/umap/Uffd.hpp
@@ -58,7 +58,7 @@ namespace Umap {
       void copy_in_page_and_write_protect(char* data, void* page_address);
 
     private:
-      RegionManager*        m_rm;
+      RegionManager&        m_rm;
       uint64_t              m_max_fault_events;
       uint64_t              m_page_size;
       Buffer*               m_buffer;

--- a/src/umap/umap.cpp
+++ b/src/umap/umap.cpp
@@ -41,69 +41,69 @@ int
 uunmap(void*  addr, uint64_t length)
 {
   UMAP_LOG(Debug, "addr: " << addr << ", length: " << length);
-  auto rm = Umap::RegionManager::getInstance();
-  rm->removeRegion((char*)addr);
+  auto& rm = Umap::RegionManager::getInstance();
+  rm.removeRegion((char*)addr);
   UMAP_LOG(Debug, "Done");
   return 0;
 }
 
 void umap_prefetch( int npages, umap_prefetch_item* page_array )
 {
-  Umap::RegionManager::getInstance()->prefetch(npages, page_array);
+  Umap::RegionManager::getInstance().prefetch(npages, page_array);
 }
 
 long
 umapcfg_get_system_page_size( void )
 {
-  return Umap::RegionManager::getInstance()->get_system_page_size();
+  return Umap::RegionManager::getInstance().get_system_page_size();
 }
 
 uint64_t
 umapcfg_get_max_pages_in_buffer( void )
 {
-  return Umap::RegionManager::getInstance()->get_max_pages_in_buffer();
+  return Umap::RegionManager::getInstance().get_max_pages_in_buffer();
 }
 
 uint64_t
 umapcfg_get_read_ahead( void )
 {
-  return Umap::RegionManager::getInstance()->get_read_ahead();
+  return Umap::RegionManager::getInstance().get_read_ahead();
 }
 
 uint64_t
 umapcfg_get_umap_page_size( void )
 {
-  return Umap::RegionManager::getInstance()->get_umap_page_size();
+  return Umap::RegionManager::getInstance().get_umap_page_size();
 }
 
 uint64_t
 umapcfg_get_num_fillers( void )
 {
-  return Umap::RegionManager::getInstance()->get_num_fillers();
+  return Umap::RegionManager::getInstance().get_num_fillers();
 }
 
 uint64_t
 umapcfg_get_num_evictors( void )
 {
-  return Umap::RegionManager::getInstance()->get_num_evictors();
+  return Umap::RegionManager::getInstance().get_num_evictors();
 }
 
 int
 umapcfg_get_evict_low_water_threshold( void )
 {
-  return Umap::RegionManager::getInstance()->get_evict_low_water_threshold();
+  return Umap::RegionManager::getInstance().get_evict_low_water_threshold();
 }
 
 int
 umapcfg_get_evict_high_water_threshold( void )
 {
-  return Umap::RegionManager::getInstance()->get_evict_high_water_threshold();
+  return Umap::RegionManager::getInstance().get_evict_high_water_threshold();
 }
 
 uint64_t
 umapcfg_get_max_fault_events( void )
 {
-  return Umap::RegionManager::getInstance()->get_max_fault_events();
+  return Umap::RegionManager::getInstance().get_max_fault_events();
 }
 
 namespace Umap {
@@ -119,8 +119,8 @@ umap_ex(
   , Store* store
 )
 {
-  auto rm = RegionManager::getInstance();
-  auto umap_psize = rm->get_umap_page_size();
+  auto& rm = RegionManager::getInstance();
+  auto umap_psize = rm.get_umap_page_size();
 
   UMAP_LOG(Debug, 
       "region_addr: " << region_addr
@@ -138,12 +138,12 @@ umap_ex(
   if ( ( region_size % umap_psize ) ) {
     UMAP_ERROR("Region size " << region_size 
                 << " is not a multple of umapPageSize (" 
-                << rm->get_umap_page_size() << ")");
+                << rm.get_umap_page_size() << ")");
   }
 
   if ( ( (uint64_t)region_addr & (umap_psize - 1) ) ) {
     UMAP_ERROR("region_addr must be page aligned: " << region_addr
-      << ", page size is: " << rm->get_umap_page_size());
+      << ", page size is: " << rm.get_umap_page_size());
   }
 
   if (!(flags & UMAP_PRIVATE) || flags & ~(UMAP_PRIVATE|UMAP_FIXED)) {
@@ -175,7 +175,7 @@ umap_ex(
   if ( store == nullptr )
     store = Store::make_store(umap_region, umap_size, umap_psize, fd);
 
-  rm->addRegion(store, (char*)umap_region, umap_size, (char*)mmap_region, mmap_size);
+  rm.addRegion(store, (char*)umap_region, umap_size, (char*)mmap_region, mmap_size);
 
   return umap_region;
 }


### PR DESCRIPTION
The region manager object was not thread-safe.  Added protection around region list.