### PR TITLE
Fixed wait_for_idle to check both waiter count and the q size

### DIFF
--- a/src/umap/WorkQueue.hpp
+++ b/src/umap/WorkQueue.hpp
@@ -69,7 +69,7 @@ class WorkQueue {
       pthread_mutex_lock(&m_mutex);
       ++m_idle_waiters;
 
-      while ( m_waiting_workers != m_max_waiting )
+      while ( ! ( m_queue.size() == 0 && m_waiting_workers == m_max_waiting ) )
         pthread_cond_wait(&m_idle_cond, &m_mutex);
 
       --m_idle_waiters;


### PR DESCRIPTION
This fixes a problem where `wait_for_idle` can return prematurely if there are no busy waiters, but there are items on the work queue which can happen if the waiters have not completely woken up yet to service the queue.