### PR TITLE
Fix bit-check for UMAP_RO_MODE

### DIFF
--- a/src/umap/umap.cpp
+++ b/src/umap/umap.cpp
@@ -146,7 +146,7 @@ umap_ex(
   );
 
 #ifdef UMAP_RO_MODE
-  if( prot | PROT_WRITE )
+  if( prot & PROT_WRITE )
     UMAP_ERROR("prot PROT_WRITE is not supported in UMAP_RO_MODE compilation");    
 #endif
     


### PR DESCRIPTION
I just started looking into this project, which seems to solve a couple of problems that we have been working on. Following the instructions from the documentation, the `prot PROT_WRITE is not supported in UMAP_RO_MODE compilation` assertion was thrown. I didn't explicitly enable `UMAP_RO_MODE`, so I have no idea why this didn't happen to anyone before.

In any case, I am almost sure that `if( prot | PROT_WRITE)` is a bug as the bit-or will always return something non-zero.